### PR TITLE
feat(assets): upload personnalisé depuis le panneau (issue #1)

### DIFF
--- a/backend/editor/pack_uploader.py
+++ b/backend/editor/pack_uploader.py
@@ -1,24 +1,48 @@
 """
 Upload and normalize custom pack assets
 """
-import os
+import re
 from pathlib import Path
 from PIL import Image
 from django.conf import settings
 from .utils import ensure_directory
 
 
+def sanitize_asset_name(name):
+    """Safe folder name under pack/category (no path traversal)."""
+    if not name or not str(name).strip():
+        raise ValueError('asset_name is required')
+    s = str(name).strip()
+    if '..' in s or '/' in s or '\\' in s:
+        raise ValueError('invalid characters in asset_name')
+    if s in ('.', '..') or s.startswith('.'):
+        raise ValueError('invalid asset_name')
+    s = re.sub(r'[\x00-\x1f<>:"|?*]', '_', s)
+    return s
+
+
+def sanitize_path_segment(seg, field_name):
+    if not seg or not str(seg).strip():
+        raise ValueError(f'{field_name} is required')
+    s = str(seg).strip()
+    if '..' in s or '/' in s or '\\' in s:
+        raise ValueError(f'invalid {field_name}')
+    return s
+
+
 class PackUploader:
     """Handle upload and normalization of custom pack assets"""
     
     def __init__(self, pack_name):
-        self.pack_name = pack_name
+        self.pack_name = sanitize_path_segment(pack_name, 'pack_name')
         # Create packs in /assets/ directory (unified location)
-        self.pack_dir = Path(settings.ASSETS_DIR) / pack_name
+        self.pack_dir = Path(settings.ASSETS_DIR) / self.pack_name
         ensure_directory(self.pack_dir)
     
     def upload_and_normalize(self, image_file, asset_name, target_size, category):
         """Upload an image and normalize it (create rotations and thumbnail)"""
+        asset_name = sanitize_asset_name(asset_name)
+        category = sanitize_path_segment(category, 'category')
         # Ensure category directory exists
         category_dir = self.pack_dir / category
         ensure_directory(category_dir)
@@ -130,6 +154,7 @@ class PackUploader:
     @staticmethod
     def create_pack(pack_name):
         """Create a new custom pack in /assets/ directory"""
+        pack_name = sanitize_path_segment(pack_name, 'pack_name')
         pack_dir = Path(settings.ASSETS_DIR) / pack_name
         ensure_directory(pack_dir)
         

--- a/frontend/src/components/AssetPanel.vue
+++ b/frontend/src/components/AssetPanel.vue
@@ -28,19 +28,39 @@
                 <img :src="getAssetThumbnail(asset)" :alt="asset.name" class="asset-thumbnail" />
                 <span class="asset-name">{{ asset.name }}</span>
               </div>
+              <button
+                v-if="!config.staticMode"
+                type="button"
+                class="asset-item asset-item-add"
+                aria-label="Ajouter un asset personnalisé dans cette catégorie"
+                @click.stop="openInlineUploader(pack.id, category)"
+              >
+                <span class="asset-add-plus" aria-hidden="true">+</span>
+                <span class="asset-name">Ajouter</span>
+              </button>
             </div>
           </div>
         </div>
       </div>
     </div>
+    <PackUploader
+      v-if="inlineUploaderOpen"
+      :show="true"
+      :pack-id="inlineUpload.packId"
+      :category-preset="inlineUpload.category"
+      @close="inlineUploaderOpen = false"
+      @uploaded="onInlineUploaded"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { usePacksStore } from '@/stores/packsStore'
 import { useAssetsStore } from '@/stores/assetsStore'
+import { config } from '@/config'
 import api from '@/services/api'
+import PackUploader from './PackUploader.vue'
 
 const packsStore = usePacksStore()
 const assetsStore = useAssetsStore()
@@ -49,6 +69,42 @@ const openPacks = ref(new Set())
 const openCategories = ref(new Map())
 
 const packs = computed(() => packsStore.packs)
+
+const inlineUploaderOpen = ref(false)
+const inlineUpload = ref({ packId: '', category: '' })
+
+const openInlineUploader = (packId, category) => {
+  inlineUpload.value = { packId, category }
+  inlineUploaderOpen.value = true
+}
+
+const onInlineUploaded = () => {
+  inlineUploaderOpen.value = false
+}
+
+const refetchPackAssets = async (packId) => {
+  try {
+    const response = await api.getPackAssets(packId)
+    if (response.data) {
+      assetsStore.setAssets(packId, response.data)
+    }
+  } catch (error) {
+    console.error('Error refreshing pack assets:', error)
+  }
+}
+
+const onPackAssetsUpdated = (e) => {
+  const packId = e.detail?.packId
+  if (packId) refetchPackAssets(packId)
+}
+
+onMounted(() => {
+  window.addEventListener('pack-assets-updated', onPackAssetsUpdated)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('pack-assets-updated', onPackAssetsUpdated)
+})
 
 const togglePack = async (packId) => {
   if (openPacks.value.has(packId)) {
@@ -266,6 +322,39 @@ const isSelected = (asset) => {
 
 .asset-item:active {
   cursor: grabbing;
+}
+
+.asset-item-add {
+  cursor: pointer;
+  border-style: dashed;
+  border-color: var(--primary-color);
+  background: rgba(255, 255, 255, 0.85);
+  justify-content: center;
+}
+
+.asset-item-add:hover {
+  background: rgba(230, 57, 70, 0.12);
+  border-color: var(--primary-color);
+}
+
+.asset-item-add:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.asset-add-plus {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  height: 60px;
+  margin-bottom: 5px;
+  font-size: 2rem;
+  font-weight: 300;
+  line-height: 1;
+  color: var(--primary-color);
+  border-radius: 4px;
+  background: rgba(230, 57, 70, 0.08);
 }
 
 .asset-thumbnail {

--- a/frontend/src/components/PackUploader.vue
+++ b/frontend/src/components/PackUploader.vue
@@ -3,47 +3,63 @@
     <div class="pack-uploader">
       <div class="modal-header">
         <h3>Upload d'Asset Personnalisé</h3>
-        <button @click="close" class="close-btn">×</button>
+        <button type="button" @click="close" class="close-btn" aria-label="Fermer">×</button>
       </div>
       <form @submit.prevent="uploadAsset" class="upload-form">
         <div class="form-group">
           <label>Fichier image</label>
-          <input type="file" @change="handleFileSelect" accept="image/*" required />
+          <input
+            ref="fileInputRef"
+            type="file"
+            @change="handleFileSelect"
+            accept="image/*"
+            required
+          />
           <div v-if="previewImage" class="preview">
-            <img :src="previewImage" alt="Preview" />
+            <img :src="previewImage" alt="Aperçu" />
           </div>
         </div>
-        
+
         <div class="form-group">
           <label>Nom de l'asset</label>
-          <input v-model="assetName" type="text" required />
+          <input v-model="assetName" type="text" required placeholder="ex. MonTuile.png" />
         </div>
-        
+
         <div class="form-group">
           <label>Taille cible (pixels)</label>
           <input v-model.number="targetSize" type="number" min="16" max="512" required />
         </div>
-        
-        <div class="form-group">
-          <label>Pack</label>
-          <select v-model="packName" @change="loadPackCategories" required>
-            <option value="">Sélectionner un pack</option>
-            <option v-for="pack in availablePacks" :key="pack.id" :value="pack.id">
-              {{ pack.name }}
-            </option>
-          </select>
-        </div>
-        
-        <div class="form-group">
-          <label>Catégorie</label>
-          <select v-model="category" :disabled="!packName || categories.length === 0" required>
-            <option value="">Sélectionner une catégorie</option>
-            <option v-for="cat in categories" :key="cat" :value="cat">
-              {{ cat }}
-            </option>
-          </select>
-        </div>
-        
+
+        <template v-if="isContextual">
+          <div class="form-group contextual-info">
+            <label>Pack</label>
+            <p class="readonly-field">{{ contextualPackTitle }}</p>
+            <label>Catégorie</label>
+            <p class="readonly-field">{{ category }}</p>
+          </div>
+        </template>
+        <template v-else>
+          <div class="form-group">
+            <label>Pack</label>
+            <select v-model="packName" @change="loadPackCategories" required>
+              <option value="">Sélectionner un pack</option>
+              <option v-for="pack in availablePacks" :key="pack.id" :value="pack.id">
+                {{ pack.name }}
+              </option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>Catégorie</label>
+            <select v-model="category" :disabled="!packName || categories.length === 0" required>
+              <option value="">Sélectionner une catégorie</option>
+              <option v-for="cat in categories" :key="cat" :value="cat">
+                {{ cat }}
+              </option>
+            </select>
+          </div>
+        </template>
+
         <button type="submit" :disabled="uploading || !packName || !category" class="submit-btn">
           {{ uploading ? 'Upload en cours...' : 'Upload et Normaliser' }}
         </button>
@@ -53,22 +69,40 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed, watch } from 'vue'
 import api from '@/services/api'
 
 const props = defineProps({
   show: {
     type: Boolean,
     default: true
+  },
+  packId: {
+    type: String,
+    default: ''
+  },
+  categoryPreset: {
+    type: String,
+    default: ''
   }
 })
 
-const emit = defineEmits(['close'])
+const emit = defineEmits(['close', 'uploaded'])
 
 const close = () => {
   emit('close')
 }
 
+const isContextual = computed(
+  () => !!(props.packId && props.categoryPreset)
+)
+
+const contextualPackTitle = computed(() => {
+  const p = availablePacks.value.find((x) => x.id === packName.value)
+  return p?.name || packName.value || props.packId
+})
+
+const fileInputRef = ref(null)
 const assetName = ref('')
 const targetSize = ref(250)
 const category = ref('')
@@ -96,7 +130,7 @@ const loadPackCategories = async () => {
     category.value = ''
     return
   }
-  
+
   try {
     const response = await api.getPackAssets(packName.value)
     if (response.data) {
@@ -111,8 +145,24 @@ const loadPackCategories = async () => {
   }
 }
 
+const syncContextualFields = () => {
+  if (props.show && isContextual.value) {
+    packName.value = props.packId
+    category.value = props.categoryPreset
+  }
+}
+
+watch(
+  () => [props.show, props.packId, props.categoryPreset],
+  () => {
+    syncContextualFields()
+  },
+  { immediate: true }
+)
+
 onMounted(async () => {
   await loadPacks()
+  syncContextualFields()
 })
 
 const handleFileSelect = (event) => {
@@ -132,14 +182,14 @@ const uploadAsset = async () => {
     alert('Veuillez sélectionner un fichier')
     return
   }
-  
+
   if (!packName.value || !category.value) {
     alert('Veuillez sélectionner un pack et une catégorie')
     return
   }
-  
+
   uploading.value = true
-  
+
   try {
     const formData = new FormData()
     formData.append('image', selectedFile.value)
@@ -147,24 +197,31 @@ const uploadAsset = async () => {
     formData.append('target_size', targetSize.value)
     formData.append('category', category.value)
     formData.append('pack_name', packName.value)
-    
+
     await api.uploadCustomPack(formData)
     alert('Asset uploadé avec succès!')
-    
-    // Reset form
+
+    const pid = packName.value
+    emit('uploaded', { packId: pid })
+    window.dispatchEvent(new CustomEvent('pack-assets-updated', { detail: { packId: pid } }))
+
     assetName.value = ''
     targetSize.value = 250
     selectedFile.value = null
     previewImage.value = null
-    category.value = ''
-    
-    // Reload packs to refresh
+    if (fileInputRef.value) {
+      fileInputRef.value.value = ''
+    }
+
+    if (!isContextual.value) {
+      category.value = ''
+    }
+
     await loadPacks()
-    // Trigger pack refresh in AssetPanel
     window.dispatchEvent(new CustomEvent('packs-refresh'))
   } catch (error) {
     console.error('Error uploading asset:', error)
-    alert('Erreur lors de l\'upload: ' + (error.response?.data?.error || error.message))
+    alert("Erreur lors de l'upload: " + (error.response?.data?.error || error.message))
   } finally {
     uploading.value = false
   }
@@ -194,7 +251,7 @@ const uploadAsset = async () => {
   overflow-y: auto;
   color: white;
   border: 2px solid var(--primary-color);
-  box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
 }
 
 .modal-header {
@@ -240,6 +297,16 @@ const uploadAsset = async () => {
   display: flex;
   flex-direction: column;
   gap: 5px;
+}
+
+.contextual-info .readonly-field {
+  margin: 0;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  border: 1px solid var(--brown-light);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.95rem;
 }
 
 .form-group label {


### PR DESCRIPTION
## Résumé
- Tuile **+** en fin de chaque grille pack → catégorie dans \AssetPanel\ (masquée en \staticMode\).
- Réutilisation de \PackUploader\ avec \packId\ + \categoryPreset\ pour préremplir pack/catégorie.
- Après upload : événement \pack-assets-updated\ + rechargement des assets ; flux header inchangé.
- Backend : validation \pack_name\, \category\, \sset_name\ dans \pack_uploader.py\.

Closes #1

Made with [Cursor](https://cursor.com)