### PR TITLE
fix(ui): thème CSS, selects lisibles, CTA statique (issue #5)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+/*
+ * Thème page d’accueil : toutes les couleurs d’accent passent par les variables :root.
+ * Thème alternatif : <html data-theme="ocean"> (exemple ci-dessous).
+ */
 :root {
     --primary-color: #e63946;
     --secondary-color: #457b9d;
@@ -6,12 +10,35 @@
     --danger-color: #bc1c1c;
     --success-color: #2a9d8f;
     --max-width: 1200px;
+    --hero-overlay: rgba(0, 0, 0, 0.7);
+    --signup-overlay: rgba(0, 0, 0, 0.8);
+    --surface-border: #eeeeee;
+    --text-on-dark: #ffffff;
+    --select-option-text: #1a1a1a;
+    --select-option-bg: #ffffff;
+    --card-shadow: rgba(0, 0, 0, 0.1);
+    --editor-mockup-shadow: rgba(0, 0, 0, 0.3);
+}
+
+html[data-theme='ocean'] {
+    --primary-color: #0077b6;
+    --secondary-color: #00b4d8;
+    --dark-color: #03045e;
+    --light-color: #caf0f8;
+    --hero-overlay: rgba(3, 4, 94, 0.75);
+    --signup-overlay: rgba(3, 4, 94, 0.82);
 }
 
 * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+}
+
+select option,
+select optgroup {
+    color: var(--select-option-text);
+    background-color: var(--select-option-bg);
 }
 
 body {
@@ -23,10 +50,10 @@ body {
 
 /* Header et Navigation */
 .hero {
-    background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
+    background: linear-gradient(var(--hero-overlay), var(--hero-overlay)),
                 url('../assets/hero-bg.jpg') center/cover;
     min-height: 100vh;
-    color: white;
+    color: var(--text-on-dark);
     display: flex;
     flex-direction: column;
 }
@@ -53,7 +80,7 @@ body {
 }
 
 .nav-links a {
-    color: white;
+    color: var(--text-on-dark);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.3s ease;
@@ -101,13 +128,13 @@ body {
 
 .btn-primary {
     background-color: var(--primary-color);
-    color: white;
+    color: var(--text-on-dark);
 }
 
 .btn-secondary {
     background-color: transparent;
-    border: 2px solid white;
-    color: white;
+    border: 2px solid var(--text-on-dark);
+    color: var(--text-on-dark);
 }
 
 .cta-buttons {
@@ -137,11 +164,11 @@ h2 {
 }
 
 .feature-card {
-    background: white;
+    background: var(--select-option-bg);
     padding: 2rem;
     border-radius: 10px;
     text-align: center;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 6px var(--card-shadow);
     transition: transform 0.3s ease;
 }
 
@@ -156,7 +183,7 @@ h2 {
 
 /* Editor Preview */
 .editor-preview {
-    background-color: white;
+    background-color: var(--select-option-bg);
 }
 
 .editor-showcase {
@@ -182,7 +209,7 @@ h2 {
     height: 100%;
     object-fit: contain;
     border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 16px var(--editor-mockup-shadow);
 }
 
 .editor-features ul {
@@ -191,7 +218,7 @@ h2 {
 
 .editor-features li {
     padding: 1rem 0;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--surface-border);
 }
 
 .editor-features li:last-child {
@@ -200,9 +227,9 @@ h2 {
 
 /* Signup Section */
 .signup {
-    background: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),
+    background: linear-gradient(var(--signup-overlay), var(--signup-overlay)),
                 url('../assets/signup-bg.jpg') center/cover;
-    color: white;
+    color: var(--text-on-dark);
     text-align: center;
 }
 
@@ -226,12 +253,14 @@ h2 {
     border: none;
     border-radius: 5px;
     font-size: 1rem;
+    color: var(--select-option-text);
+    background: var(--select-option-bg);
 }
 
 /* Footer */
 footer {
     background-color: var(--dark-color);
-    color: white;
+    color: var(--text-on-dark);
     padding: 3rem 1rem 1rem;
 }
 
@@ -249,7 +278,7 @@ footer {
 }
 
 .footer-section a {
-    color: white;
+    color: var(--text-on-dark);
     text-decoration: none;
     display: block;
     margin-bottom: 0.5rem;

--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -1,4 +1,9 @@
-/* Global styles with landing page colors */
+@import url('https://fonts.googleapis.com/css2?family=Creepster&family=Roboto:wght@300;400;700&display=swap');
+
+/*
+ * Thème de l’éditeur : couleurs centralisées dans :root.
+ * Pour un thème alternatif, définir sur <html> : data-theme="slate" (voir bloc ci-dessous).
+ */
 :root {
   --primary-color: #e63946;
   --secondary-color: #457b9d;
@@ -12,9 +17,27 @@
   --gray-dark: #2c2c2c;
   --gray-medium: #4a4a4a;
   --gray-light: #6b6b6b;
+  --editor-bg-start: var(--brown-dark);
+  --editor-bg-end: var(--gray-dark);
+  /* Liste native des <select> : fond clair côté OS — texte foncé obligatoire */
+  --select-option-text: #1a1a1a;
+  --select-option-bg: #ffffff;
+  --shadow-accent: rgba(230, 57, 70, 0.3);
 }
 
-@import url('https://fonts.googleapis.com/css2?family=Creepster&family=Roboto:wght@300;400;700&display=swap');
+html[data-theme='slate'] {
+  --primary-color: #94a3b8;
+  --secondary-color: #64748b;
+  --dark-color: #0f172a;
+  --light-color: #f8fafc;
+  --brown-dark: #1e293b;
+  --brown-medium: #334155;
+  --brown-light: #475569;
+  --gray-dark: #0f172a;
+  --gray-medium: #334155;
+  --gray-light: #64748b;
+  --shadow-accent: rgba(148, 163, 184, 0.35);
+}
 
 * {
   margin: 0;
@@ -22,9 +45,16 @@
   box-sizing: border-box;
 }
 
+/* Options du menu déroulant : lisibles sur fond clair (Windows / Chromium) */
+select option,
+select optgroup {
+  color: var(--select-option-text);
+  background-color: var(--select-option-bg);
+}
+
 body {
   font-family: 'Roboto', sans-serif;
-  background: linear-gradient(135deg, #3d2817 0%, #2c2c2c 100%);
+  background: linear-gradient(135deg, var(--editor-bg-start) 0%, var(--editor-bg-end) 100%);
   color: white;
   overflow: hidden;
 }

--- a/frontend/src/components/PackUploader.vue
+++ b/frontend/src/components/PackUploader.vue
@@ -300,7 +300,7 @@ const uploadAsset = async () => {
   background: var(--brown-light);
   border-color: var(--primary-color);
   transform: translateY(-2px);
-  box-shadow: 0 2px 8px rgba(230, 57, 70, 0.3);
+  box-shadow: 0 2px 8px var(--shadow-accent);
 }
 
 .submit-btn:disabled {

--- a/frontend/src/components/PackZipUploader.vue
+++ b/frontend/src/components/PackZipUploader.vue
@@ -246,7 +246,7 @@ onMounted(() => {
 
 .progress-bar {
   height: 100%;
-  background: #457b9d;
+  background: var(--secondary-color);
   transition: width 0.3s;
 }
 
@@ -275,7 +275,7 @@ onMounted(() => {
   background: var(--brown-light);
   border-color: var(--primary-color);
   transform: translateY(-2px);
-  box-shadow: 0 2px 8px rgba(230, 57, 70, 0.3);
+  box-shadow: 0 2px 8px var(--shadow-accent);
 }
 
 .submit-btn:disabled {
@@ -315,7 +315,7 @@ onMounted(() => {
 
 .delete-btn {
   padding: 4px 8px;
-  background: #e63946;
+  background: var(--primary-color);
   color: white;
   border: none;
   border-radius: 4px;
@@ -324,6 +324,6 @@ onMounted(() => {
 }
 
 .delete-btn:hover {
-  background: #bc1c1c;
+  background: var(--danger-color);
 }
 </style>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             <p class="subtitle">L'éditeur ultime pour donner vie à vos aventures apocalyptiques</p>
             <div class="cta-buttons">
                 <a href="#signup" class="btn btn-primary">S'inscrire à la Bêta</a>
-                <a href="editor.html" class="btn btn-secondary">En savoir plus</a>
+                <a href="editor.html" class="btn btn-secondary">Tester la version statique</a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Résumé

Correspond à [issue #5](https://github.com/paniette/zproject/issues/5).

- **Listes déroulantes** : règles globales `select option` / `optgroup` avec `--select-option-text` / `--select-option-bg` (texte foncé sur fond clair dans le menu natif).
- **Landing** : libellé du bouton secondaire → **Tester la version statique** (`index.html`).
- **Thème** : couleurs via variables `:root` ; exemples `html[data-theme="slate"]` (éditeur) et `html[data-theme="ocean"]` (accueil). Commentaires en tête des CSS.
- **Cohérence** : `PackZipUploader` / ombre `PackUploader` → variables sémantiques (`--secondary-color`, `--primary-color`, `--danger-color`, `--shadow-accent`).

Closes #5
