### PR TITLE
feat(ui): thèmes éditeur + libellé utilisateur

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="fr">
   <head>
+    <script>
+      try {
+        var _t = localStorage.getItem('zproject-editor-theme');
+        if (_t) document.documentElement.setAttribute('data-theme', _t);
+      } catch (e) {}
+    </script>
     <meta charset="UTF-8">
     <link rel="icon" type="image/svg+xml" href="/vite.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -23,8 +23,13 @@
   --select-option-text: #1a1a1a;
   --select-option-bg: #ffffff;
   --shadow-accent: rgba(230, 57, 70, 0.3);
+  --glow-soft: color-mix(in srgb, var(--primary-color) 14%, transparent);
+  --glow-strong: color-mix(in srgb, var(--primary-color) 48%, transparent);
+  --overlay-primary-weak: color-mix(in srgb, var(--primary-color) 22%, transparent);
+  --overlay-primary-mid: color-mix(in srgb, var(--primary-color) 42%, transparent);
 }
 
+/* Gris froid, interface type IDE */
 html[data-theme='slate'] {
   --primary-color: #94a3b8;
   --secondary-color: #64748b;
@@ -37,6 +42,44 @@ html[data-theme='slate'] {
   --gray-medium: #334155;
   --gray-light: #64748b;
   --shadow-accent: rgba(148, 163, 184, 0.35);
+}
+
+/* Vert infection / nécrose */
+html[data-theme='necro'] {
+  --primary-color: #bef264;
+  --secondary-color: #4d7c0f;
+  --dark-color: #14532d;
+  --light-color: #ecfccb;
+  --danger-color: #ef4444;
+  --success-color: #22c55e;
+  --brown-dark: #14532d;
+  --brown-medium: #166534;
+  --brown-light: #22c55e;
+  --gray-dark: #052e16;
+  --gray-medium: #15803d;
+  --gray-light: #4ade80;
+  --editor-bg-start: #052e16;
+  --editor-bg-end: #14532d;
+  --shadow-accent: rgba(190, 242, 100, 0.35);
+}
+
+/* Violet nuit / abyssal */
+html[data-theme='abyss'] {
+  --primary-color: #c084fc;
+  --secondary-color: #818cf8;
+  --dark-color: #1e1b4b;
+  --light-color: #e0e7ff;
+  --danger-color: #f472b6;
+  --success-color: #34d399;
+  --brown-dark: #312e81;
+  --brown-medium: #4338ca;
+  --brown-light: #6366f1;
+  --gray-dark: #1e1b4b;
+  --gray-medium: #3730a3;
+  --gray-light: #818cf8;
+  --editor-bg-start: #1e1b4b;
+  --editor-bg-end: #312e81;
+  --shadow-accent: rgba(192, 132, 252, 0.4);
 }
 
 * {

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -12,6 +12,8 @@
         />
       </div>
       <nav class="header-nav">
+        <ThemeSelector />
+        <span class="separator">|</span>
         <UserSelector />
         <span class="separator">|</span>
         <button @click="openMapLoader" class="header-btn">Charger</button>
@@ -31,6 +33,7 @@
 
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue'
+import ThemeSelector from './ThemeSelector.vue'
 import UserSelector from './UserSelector.vue'
 import MapLoader from './MapLoader.vue'
 import PackZipUploader from './PackZipUploader.vue'
@@ -294,7 +297,7 @@ const exportMap = () => {
   font-family: 'Creepster', cursive;
   font-size: 1.8rem;
   font-weight: normal;
-  color: #e63946;
+  color: var(--primary-color);
 }
 
 .header-nav {
@@ -326,6 +329,6 @@ const exportMap = () => {
   background: var(--brown-light);
   border-color: var(--primary-color);
   transform: translateY(-2px);
-  box-shadow: 0 2px 4px rgba(230, 57, 70, 0.3);
+  box-shadow: 0 2px 4px var(--shadow-accent);
 }
 </style>

--- a/frontend/src/components/AssetPanel.vue
+++ b/frontend/src/components/AssetPanel.vue
@@ -255,13 +255,13 @@ const isSelected = (asset) => {
 .asset-item:hover {
   transform: scale(1.05);
   border-color: var(--primary-color);
-  box-shadow: 0 2px 8px rgba(230, 57, 70, 0.3);
+  box-shadow: 0 2px 8px var(--shadow-accent);
 }
 
 .asset-item.selected {
   border-color: var(--primary-color);
-  background: rgba(230, 57, 70, 0.1);
-  box-shadow: 0 0 8px rgba(230, 57, 70, 0.5);
+  background: var(--glow-soft);
+  box-shadow: 0 0 8px var(--glow-strong);
 }
 
 .asset-item:active {

--- a/frontend/src/components/MapLoader.vue
+++ b/frontend/src/components/MapLoader.vue
@@ -212,7 +212,7 @@ onMounted(() => {
 }
 
 .delete-btn {
-  background: rgba(230, 57, 70, 0.2);
+  background: var(--overlay-primary-weak);
   border: 1px solid var(--primary-color);
   border-radius: 4px;
   padding: 8px 12px;
@@ -223,7 +223,7 @@ onMounted(() => {
 }
 
 .delete-btn:hover {
-  background: rgba(230, 57, 70, 0.4);
+  background: var(--overlay-primary-mid);
   transform: scale(1.1);
 }
 

--- a/frontend/src/components/ThemeSelector.vue
+++ b/frontend/src/components/ThemeSelector.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="theme-selector">
+    <label for="theme-select" class="theme-label">Thème</label>
+    <select
+      id="theme-select"
+      v-model="themeId"
+      class="theme-select"
+      aria-label="Choisir le thème de l’interface"
+    >
+      <option v-for="opt in themes" :key="opt.id" :value="opt.id">
+        {{ opt.label }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted } from 'vue'
+
+const STORAGE_KEY = 'zproject-editor-theme'
+
+const themes = [
+  { id: '', label: 'Classique (survivants)' },
+  { id: 'slate', label: 'Ardoise' },
+  { id: 'necro', label: 'Nécrose' },
+  { id: 'abyss', label: 'Abyssal' }
+]
+
+const themeId = ref('')
+
+function applyTheme (id) {
+  const root = document.documentElement
+  if (!id) {
+    root.removeAttribute('data-theme')
+  } else {
+    root.setAttribute('data-theme', id)
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, id || '')
+  } catch {
+    /* ignore */
+  }
+}
+
+onMounted(() => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved !== null && saved !== '') {
+      themeId.value = saved
+    }
+  } catch {
+    /* ignore */
+  }
+  applyTheme(themeId.value)
+})
+
+watch(themeId, (id) => applyTheme(id))
+</script>
+
+<style scoped>
+.theme-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  white-space: nowrap;
+}
+
+.theme-select {
+  padding: 6px 10px;
+  min-width: 11rem;
+  background: var(--brown-medium);
+  color: white;
+  border: 1px solid var(--brown-light);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.theme-select:hover,
+.theme-select:focus {
+  outline: none;
+  background: var(--brown-light);
+  border-color: var(--primary-color);
+}
+</style>

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -71,7 +71,7 @@ const tools = [
 .tool-btn.active {
   background: var(--primary-color);
   border-color: var(--primary-color);
-  box-shadow: 0 0 8px rgba(230, 57, 70, 0.5);
+  box-shadow: 0 0 8px var(--glow-strong);
 }
 
 .tool-icon {

--- a/frontend/src/components/UserSelector.vue
+++ b/frontend/src/components/UserSelector.vue
@@ -1,6 +1,16 @@
 <template>
-  <div class="user-selector">
-    <select v-model="selectedUser" @change="changeUser" class="user-select">
+  <div
+    class="user-selector"
+    title="Les cartes sauvegardées et chargées sont celles de cet utilisateur (profil de travail)."
+  >
+    <label for="user-select" class="user-label">Utilisateur</label>
+    <select
+      id="user-select"
+      v-model="selectedUser"
+      class="user-select"
+      aria-label="Choisir l'utilisateur actif pour les cartes"
+      @change="changeUser"
+    >
       <option v-for="user in availableUsers" :key="user" :value="user">
         {{ user }}
       </option>
@@ -38,20 +48,30 @@ const changeUser = () => {
 .user-selector {
   display: flex;
   align-items: center;
+  gap: 8px;
+}
+
+.user-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  white-space: nowrap;
 }
 
 .user-select {
   padding: 6px 12px;
+  min-width: 8rem;
   background: var(--brown-medium);
   color: white;
   border: 1px solid var(--brown-light);
   border-radius: 4px;
   cursor: pointer;
-  font-size: 14px;
-  transition: all 0.2s;
+  font-size: 13px;
+  transition: border-color 0.2s, background 0.2s;
 }
 
-.user-select:hover {
+.user-select:hover,
+.user-select:focus {
+  outline: none;
   background: var(--brown-light);
   border-color: var(--primary-color);
 }


### PR DESCRIPTION
## Résumé

Améliorations d’interface de l’éditeur Vue.

### Thèmes
- Liste déroulante **Thème** dans l’en-tête : Classique, Ardoise, Nécrose, Abyssal.
- Persistance `localStorage` (`zproject-editor-theme`) + script dans `frontend/index.html` pour limiter le flash au chargement.
- Palettes dans `frontend/src/assets/styles.css` ; halos / surcharges (`--glow-*`, `--overlay-primary-*`, `--shadow-accent`) pour que panneau assets, toolbar, modales suivent le thème.

### Utilisateur
- Libellé **Utilisateur** + infobulle expliquant le lien avec les cartes + `aria-label` sur le `select`.

### Fichiers
- Nouveau : `frontend/src/components/ThemeSelector.vue`
- Modifiés : `AppHeader.vue`, `UserSelector.vue`, `styles.css`, `index.html`, `AssetPanel.vue`, `MapLoader.vue`, `Toolbar.vue`

**Note :** cette branche inclut aussi le commit précédent `fix(ui): thème CSS, listes déroulantes lisibles, libellé CTA (issue #5)` si `main` ne l’a pas encore ; sinon GitHub n’affichera que le delta par rapport à `main`.
